### PR TITLE
Bump parent pom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>uk.gov.ons.ctp.product</groupId>
   <artifactId>collectionexercisesvc-api</artifactId>
   <version>10.49.2-SNAPSHOT</version>
   <packaging>jar</packaging>
@@ -19,7 +18,7 @@
   <parent>
     <groupId>uk.gov.ons.ctp.product</groupId>
     <artifactId>rm-common-config</artifactId>
-    <version>10.49.1-SNAPSHOT</version>
+    <version>10.49.6</version>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
The parent pom has been updated to point to an external artifactory
domain for access from travis. Pointing to the latest pom will mean
artifacts are pushed via the correct domain