### PR TITLE
Added RESET event and validation error DTO

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/CollectionExerciseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/CollectionExerciseDTO.java
@@ -113,7 +113,8 @@ public class CollectionExerciseDTO {
     VALIDATE,
     INVALIDATE,
     PUBLISH,
-    GO_LIVE
+    GO_LIVE,
+    RESET
   }
 
   @JsonIgnore

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/CollectionExerciseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/CollectionExerciseDTO.java
@@ -70,6 +70,8 @@ public class CollectionExerciseDTO {
 
   private Boolean deleted;
 
+  private SampleUnitValidationErrorDTO[] validationErrors;
+
   /**
    * Empty interface to use as a marker for validation of POST requests
    */
@@ -113,8 +115,7 @@ public class CollectionExerciseDTO {
     VALIDATE,
     INVALIDATE,
     PUBLISH,
-    GO_LIVE,
-    RESET
+    GO_LIVE
   }
 
   @JsonIgnore

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/SampleUnitValidationErrorDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/SampleUnitValidationErrorDTO.java
@@ -2,8 +2,14 @@ package uk.gov.ons.ctp.response.collection.exercise.representation;
 
 import lombok.Data;
 
+/**
+ * DTO for collection exercise validation errors
+ */
 @Data
 public class SampleUnitValidationErrorDTO {
+    /**
+     * An enum outlining the different types of validation errors that can affect sample units
+     */
     public enum ValidationError { MISSING_COLLECTION_INSTRUMENT, MISSING_PARTY }
 
     private String sampleUnitRef;

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/SampleUnitValidationErrorDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/SampleUnitValidationErrorDTO.java
@@ -1,0 +1,11 @@
+package uk.gov.ons.ctp.response.collection.exercise.representation;
+
+import lombok.Data;
+
+@Data
+public class SampleUnitValidationErrorDTO {
+    public enum ValidationError { MISSING_COLLECTION_INSTRUMENT, MISSING_PARTY }
+
+    private String sampleUnitRef;
+    private ValidationError[] errors;
+}


### PR DESCRIPTION
- Added a RESET event to the valid events for collection exercises to
allow a collection exercise that has FAILEDVALIDATION to be recovered.
- Added a DTO for describing validation errors that cause collection
exercise executions to fail