### PR TITLE
Added states and events for SampleLinks

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/LinkSampleSummaryDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/LinkSampleSummaryDTO.java
@@ -15,11 +15,17 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class LinkSampleSummaryDTO {
-  
+
+  /**
+   * Valid states for a SampleLink
+   */
   public enum SampleLinkState {
     INIT, ACTIVE
   }
 
+  /**
+   * Valid events that can be fired at a SampleLink state machine
+   */
   public enum SampleLinkEvent {
     ACTIVATE
   }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/LinkSampleSummaryDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/LinkSampleSummaryDTO.java
@@ -16,6 +16,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class LinkSampleSummaryDTO {
   
-  private List<UUID> sampleSummaryIds;
+  public enum SampleLinkState {
+    INIT, ACTIVE
+  }
 
+  public enum SampleLinkEvent {
+    ACTIVATE
+  }
+
+  private List<UUID> sampleSummaryIds;
 }


### PR DESCRIPTION
- change the sample service to create a sample summary straight away, kick off the upload in the background and return immediately
- change the collection exercise service to create a sample link immediately but only activate it when it receives a message on the sample-outbound-exchange with routing key Sample.SampleUploadFinished.binding
- change response-operations-ui to display the state of the upload and any successful completion or error