### PR TITLE
Remove state from sample link

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/LinkSampleSummaryDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/LinkSampleSummaryDTO.java
@@ -13,16 +13,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class LinkSampleSummaryDTO {
 
-  /** Valid states for a SampleLink */
-  public enum SampleLinkState {
-    INIT,
-    ACTIVE
-  }
-
-  /** Valid events that can be fired at a SampleLink state machine */
-  public enum SampleLinkEvent {
-    ACTIVATE
-  }
-
   private List<UUID> sampleSummaryIds;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/SampleLinkDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/SampleLinkDTO.java
@@ -11,5 +11,4 @@ import lombok.NoArgsConstructor;
 public class SampleLinkDTO {
   String sampleSummaryId;
   String collectionExerciseId;
-  String state;
 }


### PR DESCRIPTION
# Motivation and Context
We no longer need to keep state of the samples in collection exercise as
there is an API to get the state to know whether or not it's be loaded.

# What has changed
Removing state from sample links

# How to test?
Unit tests and acceptance tests should still pass

# Links
https://trello.com/c/RcjEiELy/181-fix-linking-a-social-sample-to-a-collection-exercise
