### PR TITLE
Removed unused survey_name from service

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/CollectionExerciseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/collection/exercise/representation/CollectionExerciseDTO.java
@@ -33,8 +33,6 @@ public class CollectionExerciseDTO {
       max = 20,
       min = 1,
       groups = {PostValidation.class, PutValidation.class, PatchValidation.class})
-  private String name;
-
   private Date actualExecutionDateTime;
 
   private Date scheduledExecutionDateTime;


### PR DESCRIPTION
### What is the Context of this PR?
This PR will have to be merged first before this PR: ONSdigital/rm-collection-exercise-service#113

Since the service name can be edited now, the one held in this service is not even the correct one i.e. out of date and the actual up to date survey details are stored in another service i.e. survey service

Card: https://trello.com/c/LP687BIU/331-remove-repeated-survey-name-from-services-other-than-survey-service-s

This PR aims to remove any ref of the survey name and drop the column entirely from the DB as well by adding a new script.

### How to Review
- Test along with the following PRs: https://github.com/ONSdigital/rm-collection-exercise-service/pull/113, https://github.com/ONSdigital/ras-party/pull/152
- Verify all instances of survey name are removed and any code referencing it.
Check builds successfully. 